### PR TITLE
speedup is_iterable by using PyIter_Check

### DIFF
--- a/src_c/isx.c
+++ b/src_c/isx.c
@@ -193,13 +193,11 @@ faster::\n\
 
 static PyObject*
 isx_IsIterable(PyObject *self, PyObject *args) {
-    PyObject *it = PyObject_GetIter(args);
-    if (it == NULL) {
-        PyErr_Clear();
+    if (PyIter_Check(args)) {
+        Py_RETURN_TRUE;
+    } else {
         Py_RETURN_FALSE;
     }
-    Py_DECREF(it);
-    Py_RETURN_TRUE;
 }
 
 

--- a/src_c/isx.c
+++ b/src_c/isx.c
@@ -192,11 +192,28 @@ faster::\n\
  *****************************************************************************/
 
 static PyObject*
-isx_IsIterable(PyObject *self, PyObject *args) {
-    if (PyIter_Check(args)) {
-        Py_RETURN_TRUE;
-    } else {
-        Py_RETURN_FALSE;
+isx_IsIterable(PyObject *self, PyObject *o) {
+    PyTypeObject *t = o->ob_type;
+    getiterfunc f = NULL;
+    f = t->tp_iter;
+
+    if (f == NULL) {
+        if (PySequence_Check(o)) {
+            Py_RETURN_TRUE;
+        } else {
+            Py_RETURN_FALSE;
+        }
+    }
+
+    else {
+        PyObject *res = (*f)(o);
+        if (res != NULL && !PyIter_Check(res)) {
+            Py_DECREF(res);
+            Py_RETURN_FALSE;
+        } else {
+            Py_DECREF(res);
+            Py_RETURN_TRUE;
+        }
     }
 }
 


### PR DESCRIPTION
This especially speeds up the `is_iterable` call if it's not iterable (6x faster) and only provides 30% speedup for iterables.