### PR TITLE
Fix freezing in deepflatten with recursive iterable datastructures.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,8 @@ Version 0.2.0 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - added ``remove`` parameter to :py:func:`~iteration_utilities.clamp`.
+- made :py:func:`~iteration_utilities.deepflatten` string-aware. For other
+  recusive-iterable classes a RecursionException is raised instead of freezing.
 
 
 Version 0.1.0 (25.1.2017)


### PR DESCRIPTION
Builtin strings, bytes and unicodes will be special cases so
that these can be iterated once.

For subclasses or other such structures a RecursionError will be
raised.

For Bugfixes:

- [x] Did you add a regression test
- [x] Did you add a changelog entry in "docs/CHANGES.rst"?