### PR TITLE
Get itertuple helper function for Merge and Roundrobin

### DIFF
--- a/src/_helper.c
+++ b/src/_helper.c
@@ -98,6 +98,34 @@ static PyObject *PyIU_global_one = NULL;
 static PyObject *PyIU_global_two = NULL;
 
 /******************************************************************************
+ * Create a new tuple containing iterators for the input-tuple.
+ *****************************************************************************/
+
+PyObject *
+PyUI_CreateIteratorTuple(PyObject *tuple)
+{
+    PyObject *newtuple;
+    Py_ssize_t i;
+    Py_ssize_t tuplesize = PyTuple_GET_SIZE(tuple);
+
+    newtuple = PyTuple_New(tuplesize);
+    if (newtuple == NULL) {
+        return NULL;
+    }
+
+    for (i = 0 ; i < tuplesize ; i++) {
+        PyObject *iterator = PyObject_GetIter(PyTuple_GET_ITEM(tuple, i));
+        if (iterator == NULL) {
+            Py_DECREF(newtuple);
+            return NULL;
+        }
+        PyTuple_SET_ITEM(newtuple, i, iterator);
+    }
+
+    return newtuple;
+}
+
+/******************************************************************************
  * Create a new reversed tuple from another tuple.
  *****************************************************************************/
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -126,15 +126,13 @@ merge_new(PyTypeObject *type,
     PyIUObject_Merge *self;
 
     PyObject *iteratortuple=NULL;
-    PyObject *iterator=NULL;
     PyObject *keyfunc=NULL;
     PyObject *reversekw=NULL;
     PyObject *funcargs=NULL;
-    Py_ssize_t numactive, idx, nkwargs;
+    Py_ssize_t nkwargs;
     int reverse = Py_LT;
 
     /* Parse arguments */
-    numactive = PyTuple_Size(args);
 
     if (kwargs != NULL && PyDict_Check(kwargs) && PyDict_Size(kwargs)) {
         nkwargs = 0;
@@ -161,30 +159,26 @@ merge_new(PyTypeObject *type,
     }
 
     /* Create and fill struct */
-    iteratortuple = PyTuple_New(numactive);
+    iteratortuple = PyUI_CreateIteratorTuple(args);
     if (iteratortuple == NULL) {
         goto Fail;
     }
-    for (idx=0 ; idx<numactive ; idx++) {
-        iterator = PyObject_GetIter(PyTuple_GET_ITEM(args, idx));
-        if (iterator == NULL) {
-            goto Fail;
-        }
-        PyTuple_SET_ITEM(iteratortuple, idx, iterator);
-    }
+
     funcargs = PyTuple_New(1);
     if (funcargs == NULL) {
         goto Fail;
     }
+
     self = (PyIUObject_Merge *)type->tp_alloc(type, 0);
     if (self == NULL) {
         goto Fail;
     }
+
     self->iteratortuple = iteratortuple;
     self->keyfunc = keyfunc;
     self->reverse = reverse;
     self->current = NULL;
-    self->numactive = numactive;
+    self->numactive = PyTuple_GET_SIZE(args);
     self->funcargs = funcargs;
     return (PyObject *)self;
 


### PR DESCRIPTION
new function for code that is shared by merge and roundrobin.

Also simplified `roundrobin.__reduce__` by using `PyTuple_GetSlice` instead of manually doing that.