### PR TITLE
Create funcargs only when necessary

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -13,7 +13,7 @@ Version 0.4.0 (unreleased)
   essentially :py:func:`functools.partial` but also allows positional
   placeholders.
 
-- several functions now interpret ``None`` like the argument for the function
+- several functions now interpret ``None`` as if that argument for the function
   wasn't given:
 
   - ``key`` argument for ``minmax``, ``merge``, ``argmin`` and ``argmax``.

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -13,7 +13,8 @@ Version 0.4.0 (unreleased)
   essentially :py:func:`functools.partial` but also allows positional
   placeholders.
 
-- several functions now also allow ``None`` as function argument:
+- several functions now interpret ``None`` like the argument for the function
+  wasn't given:
 
   - ``key`` argument for ``minmax``, ``merge``, ``argmin`` and ``argmax``.
   - ``reduce`` argument for ``groupedby``.

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -13,6 +13,12 @@ Version 0.4.0 (unreleased)
   essentially :py:func:`functools.partial` but also allows positional
   placeholders.
 
+- several functions now also allow ``None`` as function argument:
+
+  - ``key`` argument for ``minmax``, ``merge``, ``argmin`` and ``argmax``.
+  - ``reduce`` argument for ``groupedby``.
+  - all arguments for ``Seen.__new__``.
+
 
 Version 0.3.0 (2017-03-09)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/_helper.c
+++ b/src/_helper.c
@@ -94,6 +94,7 @@
  * These are created in "_module.c"!
  *****************************************************************************/
 
+static PyObject *PyIU_global_zero = NULL;
 static PyObject *PyIU_global_one = NULL;
 static PyObject *PyIU_global_two = NULL;
 static PyObject *PyIU_global_0tuple = NULL;

--- a/src/_helper.c
+++ b/src/_helper.c
@@ -22,6 +22,23 @@
 #endif
 
 /******************************************************************************
+ * Simple Convenience macros
+ *
+ * Set a value to NULL if it's None.
+ *
+ * PYIU_NULL_IF_NONE :
+ *     arg : PyObject *
+ *
+ *****************************************************************************/
+
+#define PYIU_NULL_IF_NONE(arg)     \
+    do {                           \
+        if (arg == Py_None) {      \
+           arg = NULL;             \
+        }                          \
+    } while (0)
+
+/******************************************************************************
  * Complex Convenience macros
  *
  * TODO: These are much too complex for macros but yield a 20-35% speedup over

--- a/src/_helper.c
+++ b/src/_helper.c
@@ -96,6 +96,7 @@
 
 static PyObject *PyIU_global_one = NULL;
 static PyObject *PyIU_global_two = NULL;
+static PyObject *PyIU_global_0tuple = NULL;
 
 /******************************************************************************
  * Create a new tuple containing iterators for the input-tuple.

--- a/src/_itemidxkey.c
+++ b/src/_itemidxkey.c
@@ -451,7 +451,7 @@ static PyMethodDef itemidxkey_methods[] = {
  * Docstring
  *****************************************************************************/
 
-PyDoc_STRVAR(itemidxkey_doc, "ItemIdxKey(item, idx, key=None)\n\
+PyDoc_STRVAR(itemidxkey_doc, "ItemIdxKey(item, idx, /, key)\n\
 --\n\
 \n\
 Helper class that makes it easier and faster to compare two values for\n\
@@ -466,8 +466,9 @@ idx : number\n\
     The position (index) of the `item`.\n\
 \n\
 key : any type, optional\n\
-    The `item` processed by the `key` function. If it is set then\n\
-    comparisons will compare the `key` instead of the `item`.\n\
+    If given (even as ``None``) this should be the `item` processed by the \n\
+    `key` function. If it is set then comparisons will compare the `key` \n\
+    instead of the `item`.\n\
 \n\
 Attributes\n\
 ----------\n\

--- a/src/_module.c
+++ b/src/_module.c
@@ -235,9 +235,11 @@ PyDoc_STRVAR(PyIU_module_doc, "API: C Functions\n----------------");
         PyModule_AddObject(m, PyIU_ReduceLast_name, PyIU_ReduceLast);
 
         #if PY_MAJOR_VERSION == 2
+            PyIU_global_zero = PyInt_FromLong((long)0);
             PyIU_global_one = PyInt_FromLong((long)1);
             PyIU_global_two = PyInt_FromLong((long)2);
         #else
+            PyIU_global_zero = PyLong_FromLong((long)0);
             PyIU_global_one = PyLong_FromLong((long)1);
             PyIU_global_two = PyLong_FromLong((long)2);
         #endif

--- a/src/_module.c
+++ b/src/_module.c
@@ -241,6 +241,7 @@ PyDoc_STRVAR(PyIU_module_doc, "API: C Functions\n----------------");
             PyIU_global_one = PyLong_FromLong((long)1);
             PyIU_global_two = PyLong_FromLong((long)2);
         #endif
+        PyIU_global_0tuple = PyTuple_New(0);
     }
 
 #if PY_MAJOR_VERSION >= 3

--- a/src/_returnx.c
+++ b/src/_returnx.c
@@ -30,7 +30,7 @@ PyIU_ReturnFirstArg(PyObject *m,
 {
     PyObject *first;
 
-    if (!PyTuple_Check(args) || PyTuple_Size(args) == 0) {
+    if (!PyTuple_CheckExact(args) || PyTuple_GET_SIZE(args) == 0) {
         PyErr_Format(PyExc_TypeError,
                      "Expected at least one positional argument.");
         return NULL;

--- a/src/_seen.c
+++ b/src/_seen.c
@@ -81,6 +81,12 @@ seen_new(PyTypeObject *type,
                                      &seenset, &seenlist)) {
         goto Fail;
     }
+    if (seenset == Py_None) {
+        seenset = NULL;
+    }
+    if (seenlist == Py_None) {
+        seenlist = NULL;
+    }
     if (seenset == NULL) {
         seenset = PySet_New(NULL);
         if (seenset == NULL) {
@@ -95,12 +101,8 @@ seen_new(PyTypeObject *type,
     }
 
     if (seenlist != NULL && !PyList_CheckExact(seenlist)) {
-        if (seenlist == Py_None) {
-            seenlist = NULL;
-        } else {
-            PyErr_Format(PyExc_TypeError, "`seenlist` must be a list.");
-            goto Fail;
-        }
+        PyErr_Format(PyExc_TypeError, "`seenlist` must be a list.");
+        goto Fail;
     }
 
     self = (PyIUObject_Seen *)type->tp_alloc(type, 0);
@@ -435,7 +437,7 @@ static PySequenceMethods seen_as_sequence = {
  * Docstring
  *****************************************************************************/
 
-PyDoc_STRVAR(seen_doc, "Seen(seenset, seenlist)\n\
+PyDoc_STRVAR(seen_doc, "Seen(seenset=None, seenlist=None)\n\
 --\n\
 \n\
 Helper class which adds the items after each `contains_add` check.\n\

--- a/src/_seen.c
+++ b/src/_seen.c
@@ -81,12 +81,9 @@ seen_new(PyTypeObject *type,
                                      &seenset, &seenlist)) {
         goto Fail;
     }
-    if (seenset == Py_None) {
-        seenset = NULL;
-    }
-    if (seenlist == Py_None) {
-        seenlist = NULL;
-    }
+    PYIU_NULL_IF_NONE(seenset);
+    PYIU_NULL_IF_NONE(seenlist);
+
     if (seenset == NULL) {
         seenset = PySet_New(NULL);
         if (seenset == NULL) {

--- a/src/accumulate.c
+++ b/src/accumulate.c
@@ -45,9 +45,7 @@ accumulate_new(PyTypeObject *type,
                                      &iterable, &binop, &start)) {
         goto Fail;
     }
-    if (binop == Py_None) {
-        binop = NULL;
-    }
+    PYIU_NULL_IF_NONE(binop);
 
     /* Create and fill struct */
     iterator = PyObject_GetIter(iterable);

--- a/src/accumulate.c
+++ b/src/accumulate.c
@@ -225,7 +225,7 @@ func : callable or None, optional\n\
     If ``None`` defaults to :py:func:`operator.add`.\n\
 \n\
 start : any type, optional\n\
-    If given this value is inserted before the `iterable`.\n\
+    If given (even as ``None``) this value is inserted before the `iterable`.\n\
 \n\
 Returns\n\
 -------\n\

--- a/src/accumulate.c
+++ b/src/accumulate.c
@@ -35,10 +35,10 @@ accumulate_new(PyTypeObject *type,
     PyIUObject_Accumulate *self;
 
     PyObject *iterable;
-    PyObject *iterator=NULL;
-    PyObject *binop=NULL;
-    PyObject *start=NULL;
-    PyObject *funcargs=NULL;
+    PyObject *iterator = NULL;
+    PyObject *binop = NULL;
+    PyObject *start = NULL;
+    PyObject *funcargs = NULL;
 
     /* Parse arguments */
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OO:accumulate", kwlist,
@@ -54,10 +54,14 @@ accumulate_new(PyTypeObject *type,
     if (iterator == NULL) {
         goto Fail;
     }
-    funcargs = PyTuple_New(2);
-    if (funcargs == NULL) {
-        goto Fail;
+
+    if (binop != NULL) {
+        funcargs = PyTuple_New(2);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
+
     self = (PyIUObject_Accumulate *)type->tp_alloc(type, 0);
     if (self == NULL) {
         goto Fail;

--- a/src/argminmax.c
+++ b/src/argminmax.c
@@ -160,7 +160,7 @@ PyIU_Argmax(PyObject *self,
  * Docstring
  *****************************************************************************/
 
-PyDoc_STRVAR(PyIU_Argmin_doc, "argmin(iterable, /, key=None, default=None)\n\
+PyDoc_STRVAR(PyIU_Argmin_doc, "argmin(iterable, /, key, default)\n\
 --\n\
 \n\
 Find index of the minimum.\n\
@@ -178,8 +178,8 @@ key : callable, optional\n\
     If not given then compare the values, otherwise compare ``key(item)``.\n\
 \n\
 default : int, optional\n\
-    If not given raise ``ValueError`` if the `iterable` is empty otherwise\n\
-    return ``default``\n\
+    If given an empty `iterable` will return `default` instead of raising a \n\
+    ``ValueError``.\n\
 \n\
 Returns\n\
 -------\n\

--- a/src/argminmax.c
+++ b/src/argminmax.c
@@ -22,15 +22,16 @@ argminmax(PyObject *m,
         return NULL;
     }
 
-    if (kwargs != NULL && PyDict_CheckExact(kwargs) &&
-            PyDict_GetItemString(kwargs, "default")) {
-        defaultisset = 1;
-    }
-
     if (!PyArg_ParseTupleAndKeywords(PyIU_global_0tuple, kwargs,
                                      "|On:argmin_max", kwlist,
                                      &keyfunc, &defaultitem)) {
         return NULL;
+    }
+
+    if (defaultitem != 0 ||
+            (kwargs != NULL && PyDict_CheckExact(kwargs) &&
+             PyDict_GetItemString(kwargs, "default"))) {
+        defaultisset = 1;
     }
 
     if (keyfunc == Py_None) {

--- a/src/argminmax.c
+++ b/src/argminmax.c
@@ -24,7 +24,10 @@ argminmax(PyObject *m,
         keyfunc = PyDict_GetItemString(kwargs, "key");
         if (keyfunc != NULL) {
             nkwargs++;
-            Py_INCREF(keyfunc);
+            if (keyfunc == Py_None) {
+                keyfunc = NULL;
+            }
+            Py_XINCREF(keyfunc);
         }
 
         defaultvalue = PyDict_GetItemString(kwargs, "default");

--- a/src/argminmax.c
+++ b/src/argminmax.c
@@ -33,10 +33,7 @@ argminmax(PyObject *m,
              PyDict_GetItemString(kwargs, "default"))) {
         defaultisset = 1;
     }
-
-    if (keyfunc == Py_None) {
-        keyfunc = NULL;
-    }
+    PYIU_NULL_IF_NONE(keyfunc);
     Py_XINCREF(keyfunc);
 
     if (keyfunc != NULL) {

--- a/src/argminmax.c
+++ b/src/argminmax.c
@@ -80,14 +80,14 @@ argminmax(PyObject *m,
         /* maximum value and item are set; update them as necessary. */
         } else {
             int cmpres = PyObject_RichCompareBool(val, maxval, cmpop);
-            if (cmpres < 0) {
-                goto Fail;
-            } else if (cmpres > 0) {
+            if (cmpres > 0) {
                 Py_DECREF(maxval);
                 maxval = val;
                 maxidx = idx;
-            } else {
+            } else if (cmpres == 0) {
                 Py_DECREF(val);
+            } else {
+                goto Fail;
             }
         }
         Py_DECREF(item);

--- a/src/chained.c
+++ b/src/chained.c
@@ -21,11 +21,10 @@ chained_new(PyTypeObject *type,
             PyObject *funcs,
             PyObject *kwargs)
 {
+    static char *kwlist[] = {"reverse", "all", NULL};
     PyIUObject_Chained *self;
 
-    PyObject *kwarg;
     PyObject *funcargs=NULL;
-    Py_ssize_t nkwargs;
     int reverse = 0;
     int all = 0;
 
@@ -35,26 +34,10 @@ chained_new(PyTypeObject *type,
         goto Fail;
     }
 
-    if (kwargs != NULL && PyDict_Check(kwargs) && PyDict_Size(kwargs)) {
-        nkwargs = 0;
-
-        kwarg = PyDict_GetItemString(kwargs, "reverse");
-        if (kwarg != NULL) {
-            reverse = PyLong_AsLong(kwarg);
-            nkwargs++;
-        }
-
-        kwarg = PyDict_GetItemString(kwargs, "all");
-        if (kwarg != NULL) {
-            all = PyLong_AsLong(kwarg);
-            nkwargs++;
-        }
-
-        if (PyDict_Size(kwargs) - nkwargs != 0) {
-            PyErr_Format(PyExc_TypeError,
-                         "`chained` got an unexpected keyword argument");
-            goto Fail;
-        }
+    if (!PyArg_ParseTupleAndKeywords(PyIU_global_0tuple, kwargs,
+                                     "|ii:chained", kwlist,
+                                     &reverse, &all)) {
+        return NULL;
     }
 
     if (!all) {

--- a/src/chained.c
+++ b/src/chained.c
@@ -57,9 +57,11 @@ chained_new(PyTypeObject *type,
         }
     }
 
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (!all) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
     /* Create struct */
     self = (PyIUObject_Chained *)type->tp_alloc(type, 0);
@@ -114,11 +116,12 @@ chained_call(PyIUObject_Chained *self,
              PyObject *args,
              PyObject *kwargs)
 {
-    PyObject *func, *temp, *oldtemp, *result=NULL;
-    Py_ssize_t tuplesize, idx;
-
-    tuplesize = PyTuple_Size(self->funcs);
-    temp = NULL;
+    PyObject *func;
+    PyObject *oldtemp;
+    PyObject *temp = NULL;
+    PyObject *result = NULL;
+    Py_ssize_t idx;
+    Py_ssize_t tuplesize = PyTuple_GET_SIZE(self->funcs);
 
     /* Create a placeholder tuple for "all=True".  */
     if (self->all) {

--- a/src/clamp.c
+++ b/src/clamp.c
@@ -36,12 +36,8 @@ clamp_new(PyTypeObject *type,
                                      &iterable, &low, &high, &inclusive, &remove)) {
         goto Fail;
     }
-    if (low == Py_None) {
-        low = NULL;
-    }
-    if (high == Py_None) {
-        high = NULL;
-    }
+    PYIU_NULL_IF_NONE(low);
+    PYIU_NULL_IF_NONE(high);
 
     /* Create and fill struct */
     iterator = PyObject_GetIter(iterable);

--- a/src/clamp.c
+++ b/src/clamp.c
@@ -204,10 +204,12 @@ iterable : iterable\n\
     Clamp the values from this `iterable`.\n\
 \n\
 low : any type, optional\n\
-    The lower bound for clamp.\n\
+    The lower bound for clamp. If not given or ``None`` there is no lower \n\
+    bound.\n\
 \n\
 high : any type, optional\n\
-    The upper bound for clamp.\n\
+    The upper bound for clamp. If not given or ``None`` there is no upper \n\
+    bound.\n\
 \n\
 inclusive : bool, optional\n\
     If ``True`` also remove values that are equal to `low` and `high`.\n\

--- a/src/const.c
+++ b/src/const.c
@@ -107,7 +107,7 @@ Class that always returns `x` when called.\n\
 Parameters\n\
 ----------\n\
 x : any type\n\
-    The item that should be returned when called.\n\
+    The item that should be returned when called. Positional only parameter.\n\
 \n\
 Methods\n\
 -------\n\

--- a/src/countitems.c
+++ b/src/countitems.c
@@ -30,9 +30,11 @@ PyIU_Count(PyObject *m,
         goto Fail;
     }
 
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (pred != NULL && pred != (PyObject *)&PyBool_Type) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
 
     iterator = PyObject_GetIter(iterable);

--- a/src/countitems.c
+++ b/src/countitems.c
@@ -22,9 +22,8 @@ PyIU_Count(PyObject *m,
                                      &iterable, &pred, &eq)) {
         return NULL;
     }
-    if (pred == Py_None) {
-        pred = NULL;
-    }
+    PYIU_NULL_IF_NONE(pred);
+
     if (eq && pred == NULL) {
         PyErr_Format(PyExc_TypeError, "`pred` must be specified if `eq=True`.");
         goto Fail;

--- a/src/deepflatten.c
+++ b/src/deepflatten.c
@@ -27,17 +27,23 @@ deepflatten_new(PyTypeObject *type,
     PyIUObject_DeepFlatten *self;
 
     PyObject *iterable;
-    PyObject *iterator=NULL;
-    PyObject *iteratorlist=NULL;
-    PyObject *types=NULL;
-    PyObject *ignore=NULL;
-    Py_ssize_t depth=-1;
+    PyObject *iterator = NULL;
+    PyObject *iteratorlist = NULL;
+    PyObject *types = NULL;
+    PyObject *ignore = NULL;
+    Py_ssize_t depth = -1;
     Py_ssize_t i;
 
     /* Parse arguments */
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|nOO:deepflatten", kwlist,
                                      &iterable, &depth, &types, &ignore)) {
         goto Fail;
+    }
+    if (types == Py_None) {
+        types = NULL;
+    }
+    if (ignore == Py_None) {
+        ignore = NULL;
     }
 
     /* Create and fill struct */
@@ -165,13 +171,12 @@ deepflatten_next(PyIUObject_DeepFlatten *self)
 
         /* First check if the item is an instance of the ignored types, if
            it is, then simply return it. */
-        } else if (self->ignore && self->ignore != Py_None &&
-                PyObject_IsInstance(item, self->ignore)) {
+        } else if (self->ignore && PyObject_IsInstance(item, self->ignore)) {
             return item;
 
         /* If types is given then check if it's an instance thereof and if
            so replace activeiterator, otherwise return the item. */
-        } else if (self->types && self->types != Py_None) {
+        } else if (self->types) {
             if (PyObject_IsInstance(item, self->types)) {
                 /* Check if it's a builtin-string-type and if so set
                    "isstring". Check for the exact type because sub types might

--- a/src/deepflatten.c
+++ b/src/deepflatten.c
@@ -39,12 +39,8 @@ deepflatten_new(PyTypeObject *type,
                                      &iterable, &depth, &types, &ignore)) {
         goto Fail;
     }
-    if (types == Py_None) {
-        types = NULL;
-    }
-    if (ignore == Py_None) {
-        ignore = NULL;
-    }
+    PYIU_NULL_IF_NONE(types);
+    PYIU_NULL_IF_NONE(ignore);
 
     /* Create and fill struct */
     iterator = PyObject_GetIter(iterable);

--- a/src/dotproduct.c
+++ b/src/dotproduct.c
@@ -91,7 +91,7 @@ Dot product (matrix multiplication) of two vectors.\n\
 Parameters\n\
 ----------\n\
 vec1, vec2 : iterable\n\
-    Any `iterables` to calculate the dot product.\n\
+    Any `iterables` to calculate the dot product. Positional-only parameter.\n\
 \n\
 Returns\n\
 -------\n\

--- a/src/duplicates.c
+++ b/src/duplicates.c
@@ -31,10 +31,10 @@ duplicates_new(PyTypeObject *type,
     PyIUObject_Duplicates *self;
 
     PyObject *iterable;
-    PyObject *iterator=NULL;
-    PyObject *seen=NULL;
-    PyObject *key=NULL;
-    PyObject *funcargs=NULL;
+    PyObject *iterator = NULL;
+    PyObject *seen = NULL;
+    PyObject *key = NULL;
+    PyObject *funcargs = NULL;
 
     /* Parse arguments */
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O:duplicates", kwlist,
@@ -44,9 +44,11 @@ duplicates_new(PyTypeObject *type,
     if (key == Py_None) {
         key = NULL;
     }
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (key != NULL) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
 
     /* Create and fill struct */

--- a/src/duplicates.c
+++ b/src/duplicates.c
@@ -41,9 +41,8 @@ duplicates_new(PyTypeObject *type,
                                      &iterable, &key)) {
         goto Fail;
     }
-    if (key == Py_None) {
-        key = NULL;
-    }
+    PYIU_NULL_IF_NONE(key);
+
     if (key != NULL) {
         funcargs = PyTuple_New(1);
         if (funcargs == NULL) {

--- a/src/flip.c
+++ b/src/flip.c
@@ -118,6 +118,7 @@ Parameters\n\
 ----------\n\
 func : callable\n\
     The function that should be called with the flipped (reversed) arguments.\n\
+    Positional-only parameter.\n\
 \n\
 Methods\n\
 -------\n\

--- a/src/groupedby.c
+++ b/src/groupedby.c
@@ -11,18 +11,18 @@ PyIU_Groupby(PyObject *m,
 
     PyObject *iterable;
     PyObject *key1;
-    PyObject *key2=NULL;
-    PyObject *iterator=NULL;
+    PyObject *key2 = NULL;
+    PyObject *iterator = NULL;
     PyObject *item;
     PyObject *val;
     PyObject *lst;
     PyObject *keep;
-    PyObject *reduce=NULL;
-    PyObject *reducestart=NULL;
-    PyObject *reducetmp=NULL;
-    PyObject *resdict=NULL;
-    PyObject *funcargs1=NULL;
-    PyObject *funcargs2=NULL;
+    PyObject *reduce = NULL;
+    PyObject *reducestart = NULL;
+    PyObject *reducetmp = NULL;
+    PyObject *resdict = NULL;
+    PyObject *funcargs1 = NULL;
+    PyObject *funcargs2 = NULL;
     int ok;
 #if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 5)
     Py_hash_t hash;
@@ -33,6 +33,11 @@ PyIU_Groupby(PyObject *m,
                                      &reducestart)) {
         goto Fail;
     }
+
+    if (reduce == Py_None) {
+        reduce = NULL;
+    }
+
     if (reduce == NULL && reducestart != NULL) {
         PyErr_Format(PyExc_TypeError,
                      "cannot specify `reducestart` if no `reduce` is given.");
@@ -43,17 +48,22 @@ PyIU_Groupby(PyObject *m,
     if (iterator == NULL) {
         goto Fail;
     }
+
     resdict = PyDict_New();
     if (resdict == NULL) {
         goto Fail;
     }
+
     funcargs1 = PyTuple_New(1);
     if (funcargs1 == NULL) {
         goto Fail;
     }
-    funcargs2 = PyTuple_New(2);
-    if (funcargs2 == NULL) {
-        goto Fail;
+
+    if (reduce != NULL) {
+        funcargs2 = PyTuple_New(2);
+        if (funcargs2 == NULL) {
+            goto Fail;
+        }
     }
 
     while ( (item = (*Py_TYPE(iterator)->tp_iternext)(iterator)) ) {
@@ -182,7 +192,7 @@ PyIU_Groupby(PyObject *m,
     }
 
     Py_DECREF(funcargs1);
-    Py_DECREF(funcargs2);
+    Py_XDECREF(funcargs2);
     Py_DECREF(iterator);
 
     if (PyErr_Occurred()) {

--- a/src/groupedby.c
+++ b/src/groupedby.c
@@ -240,8 +240,11 @@ reduce : callable, optional\n\
     in :py:func:`functools.reduce`.\n\
 \n\
 reducestart : any type, optional\n\
-    Can only be specified if `reduce` is given. This parameter is equivalent\n\
-    to the `start` parameter of :py:func:`functools.reduce`.\n\
+    If given (even as ``None``) it will be interpreted as startvalue for the\n\
+    `reduce` function.\n\
+    \n\
+    .. note::\n\
+       Can only be specified if `reduce` is given.\n\
 \n\
 Returns\n\
 -------\n\

--- a/src/groupedby.c
+++ b/src/groupedby.c
@@ -34,9 +34,8 @@ PyIU_Groupby(PyObject *m,
         goto Fail;
     }
 
-    if (reduce == Py_None) {
-        reduce = NULL;
-    }
+    PYIU_NULL_IF_NONE(reduce);
+    PYIU_NULL_IF_NONE(key2);
 
     if (reduce == NULL && reducestart != NULL) {
         PyErr_Format(PyExc_TypeError,
@@ -76,7 +75,7 @@ PyIU_Groupby(PyObject *m,
         }
 
         /* Calculate the value for the dictionary (keep).  */
-        if (key2 == NULL || key2 == Py_None) {
+        if (key2 == NULL) {
             keep = item;
         } else {
             /* We use the same item again to calculate the keep so we don't need

--- a/src/grouper.c
+++ b/src/grouper.c
@@ -246,9 +246,7 @@ grouper_setstate(PyIUObject_Grouper *self,
     if (!PyArg_ParseTuple(state, "Oi", &result, &truncate)) {
         return NULL;
     }
-    if (result == Py_None) {
-        result = NULL;
-    }
+    PYIU_NULL_IF_NONE(result);
 
     Py_CLEAR(self->result);
     Py_XINCREF(result);

--- a/src/grouper.c
+++ b/src/grouper.c
@@ -309,7 +309,8 @@ n : :py:class:`int`\n\
 fillvalue : any type, optional\n\
     The `fillvalue` if the `iterable` is consumed and the last yielded group\n\
     should be filled. If not given the last yielded group may be shorter\n\
-    than the group before.\n\
+    than the group before. Using ``fillvalue=None`` is different from not \n\
+    giving a `fillvalue` in that the last group will be filled with ``None``.\n\
 \n\
 truncate : bool, optional\n\
     As alternative to `fillvalue` the last group is discarded if it is\n\

--- a/src/iterexcept.c
+++ b/src/iterexcept.c
@@ -30,9 +30,7 @@ iterexcept_new(PyTypeObject *type,
                                      &func, &except, &first)) {
         return NULL;
     }
-    if (first == Py_None) {
-        first = NULL;
-    }
+    PYIU_NULL_IF_NONE(first);
 
     /* Create and fill struct */
     self = (PyIUObject_Iterexcept *)type->tp_alloc(type, 0);
@@ -91,8 +89,7 @@ iterexcept_next(PyIUObject_Iterexcept *self)
         result = PyObject_CallObject(self->func, NULL);
     } else {
         result = PyObject_CallObject(self->first, NULL);
-        Py_DECREF(self->first);
-        self->first = NULL;
+        Py_CLEAR(self->first);
     }
 
     /* Stop if the result is NULL but only clear the exception if the expected

--- a/src/iterexcept.c
+++ b/src/iterexcept.c
@@ -151,8 +151,8 @@ exception : Exception\n\
     The `exception` which terminates the iteration.\n\
 \n\
 first : callable or None, optional\n\
-    If not ``None`` this function is called once before the `func` is\n\
-    executed.\n\
+    If not given (or not ``None``) this function is called once before the \n\
+    `func` is executed.\n\
 \n\
 Returns\n\
 -------\n\

--- a/src/merge.c
+++ b/src/merge.c
@@ -141,9 +141,7 @@ merge_new(PyTypeObject *type,
 
     reverse = reverse ? Py_GT : Py_LT;
 
-    if (keyfunc == Py_None) {
-        keyfunc = NULL;
-    }
+    PYIU_NULL_IF_NONE(keyfunc);
     Py_XINCREF(keyfunc);
 
     /* Create and fill struct */
@@ -291,7 +289,7 @@ merge_next(PyIUObject_Merge *self)
     PyIUObject_ItemIdxKey *next;
 
     /* No current then we create one. */
-    if (self->current == NULL || self->current == Py_None) {
+    if (self->current == NULL) {
         if (merge_init_current(self) < 0) {
             return NULL;
         }
@@ -399,6 +397,7 @@ merge_setstate(PyIUObject_Merge *self,
                           &keyfunc, &reverse, &current, &numactive)) {
         return NULL;
     }
+    PYIU_NULL_IF_NONE(current);
 
     if (keyfunc != Py_None) {
         funcargs = PyTuple_New(1);
@@ -414,7 +413,7 @@ merge_setstate(PyIUObject_Merge *self,
 
     Py_CLEAR(self->current);
     self->current = current;
-    Py_INCREF(self->current);
+    Py_XINCREF(self->current);
 
     self->numactive = numactive;
     self->reverse = reverse;
@@ -430,7 +429,7 @@ static PyObject *
 merge_lengthhint(PyIUObject_Merge *self)
 {
     Py_ssize_t i, len = 0;
-    if (self->current == NULL || self->current == Py_None) {
+    if (self->current == NULL) {
         for (i=0 ; i<PyTuple_Size(self->iteratortuple) ; i++) {
             len = len + PyObject_LengthHint(PyTuple_GET_ITEM(self->iteratortuple, i), 0);
         }

--- a/src/merge.c
+++ b/src/merge.c
@@ -123,6 +123,7 @@ merge_new(PyTypeObject *type,
           PyObject *args,
           PyObject *kwargs)
 {
+    static char *kwlist[] = {"key", "reverse", NULL};
     PyIUObject_Merge *self;
 
     PyObject *iteratortuple=NULL;
@@ -130,37 +131,22 @@ merge_new(PyTypeObject *type,
     PyObject *reversekw=NULL;
     PyObject *funcargs=NULL;
     Py_ssize_t nkwargs;
-    int reverse = Py_LT;
+    int reverse = 0;
 
     /* Parse arguments */
 
-    if (kwargs != NULL && PyDict_Check(kwargs) && PyDict_Size(kwargs)) {
-        nkwargs = 0;
-
-        keyfunc = PyDict_GetItemString(kwargs, "key");
-
-        if (keyfunc != NULL) {
-            nkwargs++;
-            if (keyfunc == Py_None) {
-                keyfunc = NULL;
-            }
-            Py_XINCREF(keyfunc);
-        }
-
-        reversekw = PyDict_GetItemString(kwargs, "reverse");
-        if (reversekw != NULL) {
-            nkwargs++;
-            if (PyObject_IsTrue(reversekw)) {
-                reverse = Py_GT;
-            }
-        }
-
-        if (PyDict_Size(kwargs) - nkwargs != 0) {
-            PyErr_Format(PyExc_TypeError,
-                         "merge got an unexpected keyword argument");
-            goto Fail;
-        }
+    if (!PyArg_ParseTupleAndKeywords(PyIU_global_0tuple, kwargs,
+                                     "|OO:merge", kwlist,
+                                     &keyfunc, &reverse)) {
+        return NULL;
     }
+
+    reverse = reverse ? Py_GT : Py_LT;
+
+    if (keyfunc == Py_None) {
+        keyfunc = NULL;
+    }
+    Py_XINCREF(keyfunc);
 
     /* Create and fill struct */
     iteratortuple = PyUI_CreateIteratorTuple(args);

--- a/src/merge.c
+++ b/src/merge.c
@@ -126,10 +126,9 @@ merge_new(PyTypeObject *type,
     static char *kwlist[] = {"key", "reverse", NULL};
     PyIUObject_Merge *self;
 
-    PyObject *iteratortuple=NULL;
-    PyObject *keyfunc=NULL;
-    PyObject *reversekw=NULL;
-    PyObject *funcargs=NULL;
+    PyObject *iteratortuple = NULL;
+    PyObject *keyfunc = NULL;
+    PyObject *funcargs = NULL;
     int reverse = 0;
 
     /* Parse arguments */

--- a/src/merge.c
+++ b/src/merge.c
@@ -130,7 +130,6 @@ merge_new(PyTypeObject *type,
     PyObject *keyfunc=NULL;
     PyObject *reversekw=NULL;
     PyObject *funcargs=NULL;
-    Py_ssize_t nkwargs;
     int reverse = 0;
 
     /* Parse arguments */

--- a/src/minmax.c
+++ b/src/minmax.c
@@ -26,6 +26,9 @@ PyIU_MinMax(PyObject *m,
         keyfunc = PyDict_GetItemString(kwargs, "key");
         if (keyfunc != NULL) {
             nkwargs++;
+            if (keyfunc == Py_None) {
+                keyfunc = NULL;
+            }
             Py_INCREF(keyfunc);
         }
 
@@ -47,9 +50,12 @@ PyIU_MinMax(PyObject *m,
                      "positional arguments");
         goto Fail;
     }
-    funcargs = PyTuple_New(0);
-    if (funcargs == NULL) {
-        goto Fail;
+
+    if (keyfunc != NULL) {
+        funcargs = PyTuple_New(0);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
 
     iterator = PyObject_GetIter(sequence);
@@ -236,7 +242,7 @@ PyIU_MinMax(PyObject *m,
     }
 
     Py_DECREF(iterator);
-    Py_DECREF(funcargs);
+    Py_XDECREF(funcargs);
     Py_XDECREF(keyfunc);
     Py_XDECREF(defaultitem);
 

--- a/src/minmax.c
+++ b/src/minmax.c
@@ -7,12 +7,13 @@ PyIU_MinMax(PyObject *m,
             PyObject *args,
             PyObject *kwargs)
 {
+    static char *kwlist[] = {"key", "default", NULL};
+
     PyObject *sequence, *iterator=NULL, *defaultitem = NULL, *keyfunc = NULL;
     PyObject *item1 = NULL, *item2 = NULL, *val1 = NULL, *val2 = NULL;
     PyObject *maxitem = NULL, *maxval = NULL, *minitem = NULL, *minval = NULL;
     PyObject *temp = NULL, *resulttuple = NULL;
     PyObject *funcargs=NULL;
-    Py_ssize_t nkwargs = 0;
     int cmp;
     const int positional = PyTuple_Size(args) > 1;
 
@@ -21,29 +22,18 @@ PyIU_MinMax(PyObject *m,
     } else if (!PyArg_UnpackTuple(args, "minmax", 1, 1, &sequence)) {
         return NULL;
     }
-    if (kwargs != NULL && PyDict_Check(kwargs) && PyDict_Size(kwargs)) {
 
-        keyfunc = PyDict_GetItemString(kwargs, "key");
-        if (keyfunc != NULL) {
-            nkwargs++;
-            if (keyfunc == Py_None) {
-                keyfunc = NULL;
-            }
-            Py_INCREF(keyfunc);
-        }
-
-        defaultitem = PyDict_GetItemString(kwargs, "default");
-        if (defaultitem != NULL) {
-            nkwargs++;
-            Py_INCREF(defaultitem);
-        }
-
-        if (PyDict_Size(kwargs) - nkwargs != 0) {
-            PyErr_Format(PyExc_TypeError,
-                         "minmax got an unexpected keyword argument");
-            goto Fail;
-        }
+    if (!PyArg_ParseTupleAndKeywords(PyIU_global_0tuple, kwargs,
+                                     "|OO:minmax", kwlist,
+                                     &keyfunc, &defaultitem)) {
+        return NULL;
     }
+
+    if (keyfunc == Py_None) {
+        keyfunc = NULL;
+    }
+    Py_XINCREF(keyfunc);
+
     if (positional && defaultitem != NULL) {
         PyErr_Format(PyExc_TypeError,
                      "Cannot specify a default for minmax with multiple "

--- a/src/minmax.c
+++ b/src/minmax.c
@@ -29,9 +29,7 @@ PyIU_MinMax(PyObject *m,
         return NULL;
     }
 
-    if (keyfunc == Py_None) {
-        keyfunc = NULL;
-    }
+    PYIU_NULL_IF_NONE(keyfunc);
     Py_XINCREF(keyfunc);
 
     if (positional && defaultitem != NULL) {

--- a/src/minmax.c
+++ b/src/minmax.c
@@ -159,9 +159,7 @@ PyIU_MinMax(PyObject *m,
             } else {
                 /* If both are set swap them if val2 is smaller than val1. */
                 cmp = PyObject_RichCompareBool(val2, val1, Py_LT);
-                if (cmp < 0) {
-                    goto Fail;
-                } else if (cmp > 0) {
+                if (cmp > 0) {
                     temp = val1;
                     val1 = val2;
                     val2 = temp;
@@ -169,6 +167,8 @@ PyIU_MinMax(PyObject *m,
                     temp = item1;
                     item1 = item2;
                     item2 = temp;
+                } else if (cmp < 0) {
+                    goto Fail;
                 }
             }
 
@@ -176,30 +176,30 @@ PyIU_MinMax(PyObject *m,
                the current minimum.
                */
             cmp = PyObject_RichCompareBool(val1, minval, Py_LT);
-            if (cmp < 0) {
-                goto Fail;
-            } else if (cmp > 0) {
+            if (cmp > 0) {
                 Py_DECREF(minval);
                 Py_DECREF(minitem);
                 minval = val1;
                 minitem = item1;
-            } else {
+            } else if (cmp == 0) {
                 Py_DECREF(item1);
                 Py_DECREF(val1);
+            } else {
+                goto Fail;
             }
 
             /* Same for maximum. */
             cmp = PyObject_RichCompareBool(val2, maxval, Py_GT);
-            if (cmp < 0) {
-                goto Fail;
-            } else if (cmp > 0) {
+            if (cmp > 0) {
                 Py_DECREF(maxval);
                 Py_DECREF(maxitem);
                 maxval = val2;
                 maxitem = item2;
-            } else {
+            } else if (cmp == 0) {
                 Py_DECREF(item2);
                 Py_DECREF(val2);
+            } else  {
+                goto Fail;
             }
         }
     }

--- a/src/nth.c
+++ b/src/nth.c
@@ -98,6 +98,10 @@ nth_call(PyIUObject_Nth *self,
         return NULL;
     }
 
+    if (func == (PyObject *)&PyBool_Type) {
+        func = Py_None;
+    }
+
     if (retpred && retidx) {
         PyErr_Format(PyExc_ValueError,
                      "can only specify `retpred` or `retidx`.");
@@ -146,10 +150,10 @@ nth_call(PyIUObject_Nth *self,
             idx++;
             continue;
 
-        /* If "None" or "bool" is given as predicate we don't need to call the
-           function explicitly.
+        /* If "None" (or "bool") is given as predicate we don't need to call
+           the function explicitly.
            */
-        } else if (func == Py_None || func == (PyObject *)&PyBool_Type) {
+        } else if (func == Py_None) {
             ok = PyObject_IsTrue(item);
 
         /* Otherwise call the function.  */
@@ -298,6 +302,9 @@ default : any type, optional\n\
 \n\
 pred : callable, optional\n\
     If given return the nth item for which ``pred(item)`` is ``True``.\n\
+    \n\
+    .. note::\n\
+       ``pred=None`` is equivalent to ``pred=bool``.\n\
 \n\
 truthy : bool, optional\n\
     If ``False`` search for the nth item for which ``pred(item)`` is ``False``.\n\

--- a/src/packed.c
+++ b/src/packed.c
@@ -127,6 +127,7 @@ Parameters\n\
 ----------\n\
 func : callable\n\
     The function that should be called when the packed-instance is called.\n\
+    Positional-only parameter.\n\
 \n\
 Methods\n\
 -------\n\

--- a/src/partial.c
+++ b/src/partial.c
@@ -662,12 +662,8 @@ partial_setstate(PyIUObject_Partial *self, PyObject *state)
     }
 
     Py_INCREF(fn);
-    if (dict == Py_None) {
-        dict = NULL;
-    }
-    else {
-        Py_INCREF(dict);
-    }
+    PYIU_NULL_IF_NONE(dict);
+    Py_XINCREF(dict);
 
     Py_CLEAR(self->fn);
     Py_CLEAR(self->args);

--- a/src/split.c
+++ b/src/split.c
@@ -60,9 +60,11 @@ split_new(PyTypeObject *type,
     if (iterator == NULL) {
         goto Fail;
     }
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (!cmp) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
     self = (PyIUObject_Split *)type->tp_alloc(type, 0);
     if (self == NULL) {

--- a/src/successive.c
+++ b/src/successive.c
@@ -238,7 +238,7 @@ static PyMethodDef successive_methods[] = {
  * Docstring
  *****************************************************************************/
 
-PyDoc_STRVAR(successive_doc, "successive(iterable, times)\n\
+PyDoc_STRVAR(successive_doc, "successive(iterable, times=2)\n\
 --\n\
 \n\
 Like the recipe for pairwise but allows to get an arbitary number\n\

--- a/src/successive.c
+++ b/src/successive.c
@@ -186,14 +186,10 @@ successive_setstate(PyIUObject_Successive *self,
         return NULL;
     }
 
+    PYIU_NULL_IF_NONE(result);
     Py_CLEAR(self->result);
-
-    if (result == Py_None) {
-        self->result = NULL;
-    } else {
-        Py_INCREF(result);
-        self->result = result;
-    }
+    self->result = result;
+    Py_XINCREF(result);
 
     Py_RETURN_NONE;
 }

--- a/src/tabulate.c
+++ b/src/tabulate.c
@@ -31,17 +31,10 @@ tabulate_new(PyTypeObject *type,
         goto Fail;
     }
     if (cnt == NULL) {
-#if PY_MAJOR_VERSION == 2
-        cnt = PyInt_FromLong(0);
-#else
-        cnt = PyLong_FromLong(0);
-#endif
-        if (cnt == NULL) {
-            goto Fail;
-        }
-    } else {
-        Py_INCREF(cnt);
+        cnt = PyIU_global_zero;
     }
+    Py_INCREF(cnt);
+
     funcargs = PyTuple_New(1);
     if (funcargs == NULL) {
         goto Fail;

--- a/src/uniqueever.c
+++ b/src/uniqueever.c
@@ -41,9 +41,7 @@ uniqueever_new(PyTypeObject *type,
                                      &iterable, &key)) {
         goto Fail;
     }
-    if (key == Py_None) {
-        key = NULL;
-    }
+    PYIU_NULL_IF_NONE(key);
 
     /* Create and fill struct */
     iterator = PyObject_GetIter(iterable);

--- a/src/uniqueever.c
+++ b/src/uniqueever.c
@@ -54,9 +54,11 @@ uniqueever_new(PyTypeObject *type,
     if (seen == NULL) {
         goto Fail;
     }
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (key != NULL) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
     self = (PyIUObject_UniqueEver *)type->tp_alloc(type, 0);
     if (self == NULL) {

--- a/src/uniquejust.c
+++ b/src/uniquejust.c
@@ -43,9 +43,11 @@ uniquejust_new(PyTypeObject *type,
     if (iterator == NULL) {
         goto Fail;
     }
-    funcargs = PyTuple_New(1);
-    if (funcargs == NULL) {
-        goto Fail;
+    if (keyfunc != NULL) {
+        funcargs = PyTuple_New(1);
+        if (funcargs == NULL) {
+            goto Fail;
+        }
     }
     self = (PyIUObject_UniqueJust *)type->tp_alloc(type, 0);
     if (self == NULL) {

--- a/src/uniquejust.c
+++ b/src/uniquejust.c
@@ -36,9 +36,8 @@ uniquejust_new(PyTypeObject *type,
     }
 
     /* Create and fill struct */
-    if (keyfunc == Py_None) {
-        keyfunc = NULL;
-    }
+    PYIU_NULL_IF_NONE(keyfunc);
+
     iterator = PyObject_GetIter(iterable);
     if (iterator == NULL) {
         goto Fail;

--- a/tests/test_accumulate.py
+++ b/tests/test_accumulate.py
@@ -29,13 +29,14 @@ def test_accumulate_normal1():
 
 @memory_leak_decorator()
 def test_accumulate_normal2():
+    # binop=None is identical to no binop
     assert list(accumulate([], None)) == []
 
 
 @memory_leak_decorator()
 def test_accumulate_normal3():
-    assert list(accumulate([T(1), T(2), T(3), T(4)],
-                           None)) == [T(1), T(3), T(6), T(10)]
+    # binop=None is identical to no binop
+    assert list(accumulate([T(1), T(2), T(3)], None)) == [T(1), T(3), T(6)]
 
 
 @memory_leak_decorator()

--- a/tests/test_argminmax.py
+++ b/tests/test_argminmax.py
@@ -33,6 +33,12 @@ def test_argmin_positional2():
 
 
 @memory_leak_decorator()
+def test_argmin_positional3():
+    # key=None is identical to no key
+    assert argmin(T(3), T(1), T(2), key=None) == 1
+
+
+@memory_leak_decorator()
 def test_argmin_sequence1():
     assert argmin([T(3), T(0), T(1)]) == 1
 

--- a/tests/test_groupedby.py
+++ b/tests/test_groupedby.py
@@ -77,6 +77,14 @@ def test_groupedby_reduce3():
                      reducestart=T(0))
 
 
+@memory_leak_decorator()
+def test_groupedby_reduce4():
+    # reduce=None is identical to no reduce
+    assert groupedby([T(1), T(1), T(2), T(3)], lambda x: x,
+                     reduce=None) == {T(1): [T(1), T(1)],
+                                      T(2): [T(2)], T(3): [T(3)]}
+
+
 @memory_leak_decorator(collect=True)
 def test_groupedby_failure1():
     # not iterable

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -81,6 +81,12 @@ def test_merge_normal5():
 
 
 @memory_leak_decorator()
+def test_merge_normal6():
+    # key=None is identical to no key
+    assert list(merge([T(1)], [T(2)], key=None)) == [T(1), T(2)]
+
+
+@memory_leak_decorator()
 def test_merge_stable1():
     # Stability tests (no use of T on purpose!)
     it = merge([1], [1.])

--- a/tests/test_minmax.py
+++ b/tests/test_minmax.py
@@ -91,6 +91,12 @@ def test_minmax_normal15():
 
 
 @memory_leak_decorator()
+def test_minmax_keyNone1():
+    # key=None is identical to no key
+    assert minmax([T(1), T(2)], key=None) == (T(1), T(2))
+
+
+@memory_leak_decorator()
 def test_minmax_key1():
     assert minmax(T('a'), T('b'), T('c'),
                   key=lambda x: x.value.upper()) == (T('a'), T('c'))

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -47,6 +47,12 @@ def test_partition_normal5():
 
 
 @memory_leak_decorator()
+def test_partition_normal6():
+    # pred=None is identical to no pred
+    assert partition([T(0), T(1), T(2)], None) == (toT([0]), toT([1, 2]))
+
+
+@memory_leak_decorator()
 def test_partition_pred1():
     assert partition([T(0), T(1), T(2)],
                      lambda x: x.value > 1) == (toT([0, 1]), toT([2]))

--- a/tests/test_seen.py
+++ b/tests/test_seen.py
@@ -16,6 +16,18 @@ Seen = iteration_utilities.Seen
 
 
 @memory_leak_decorator()
+def test_seen_new_None1():
+    # seenset=None is identical to no seenset
+    assert Seen(None) == Seen()
+
+
+@memory_leak_decorator()
+def test_seen_new_None2():
+    # seenlist=None is identical to no seenlist
+    assert Seen(set(), None) == Seen(set())
+
+
+@memory_leak_decorator()
 def test_seen_equality0():
     assert Seen() == Seen()
 

--- a/tests/test_unique_everseen.py
+++ b/tests/test_unique_everseen.py
@@ -29,6 +29,12 @@ def test_uniqueeverseen_normal1():
 
 
 @memory_leak_decorator()
+def test_uniqueeverseen_normal2():
+    # key=None is identical to no key
+    assert list(unique_everseen([T(1), T(2), T(1)], None)) == [T(1), T(2)]
+
+
+@memory_leak_decorator()
 def test_uniqueeverseen_key1():
     assert list(unique_everseen([T(1), T(2), T(1)], abs)) == [T(1), T(2)]
 

--- a/tests/test_unique_justseen.py
+++ b/tests/test_unique_justseen.py
@@ -47,6 +47,13 @@ def test_unique_justseen_normal3():
     assert list(unique_justseen('aAabBb', key=str.lower)) == ['a', 'b']
 
 
+@memory_leak_decorator()
+def test_unique_justseen_normal4():
+    # key=None is identical to no key
+    assert list(unique_justseen(toT([1, 1, 2, 2, 3, 3]),
+                                None)) == toT([1, 2, 3])
+
+
 @memory_leak_decorator(collect=True)
 def test_unique_justseen_failure1():
     # not iterable


### PR DESCRIPTION
Check which functions now "really" allow None as parameter. Candidates: `argmin, argmax, minmax, groupedby (reduce), merge`