### PR TITLE
Create a size-1 tuple for the function arguments in minmax.

### DIFF
--- a/src/minmax.c
+++ b/src/minmax.c
@@ -40,7 +40,7 @@ PyIU_MinMax(PyObject *Py_UNUSED(m),
     }
 
     if (keyfunc != NULL) {
-        funcargs = PyTuple_New(0);
+        funcargs = PyTuple_New(1);
         if (funcargs == NULL) {
             goto Fail;
         }


### PR DESCRIPTION
Luckily the empty tuple is a singleton with a reference count of more
than 1, so the PYIU_RECYCLE_ARG_TUPLE macro created a size-1-tuple
before the element was actually set. Otherwise this would try to
access the first element of a size-0-tuple without check...